### PR TITLE
Add full bash port of zsh setup with slim shell base

### DIFF
--- a/.bash_profile
+++ b/.bash_profile
@@ -1,0 +1,4 @@
+# Login shells (notably macOS Terminal.app, which starts every tab as a login
+# shell) read .bash_profile but NOT .bashrc. Source .bashrc here so interactive
+# login shells get the same configuration.
+[[ -r ~/.bashrc ]] && source ~/.bashrc

--- a/.bashrc
+++ b/.bashrc
@@ -1,0 +1,12 @@
+# Entry point for interactive bash shells.
+# The real configuration lives in $XDG_CONFIG_HOME/bash to mirror the zsh setup
+# (which keeps everything under $ZDOTDIR). See .config/bash/ for the modules.
+
+# If not running interactively, don't do anything.
+case $- in
+    *i*) ;;
+    *) return ;;
+esac
+
+BASH_CONF_DIR="${XDG_CONFIG_HOME:-$HOME/.config}/bash"
+[[ -r "$BASH_CONF_DIR/bashrc" ]] && source "$BASH_CONF_DIR/bashrc"

--- a/.config/bash/aliases/containers.bash
+++ b/.config/bash/aliases/containers.bash
@@ -1,0 +1,21 @@
+# ====== #
+# DOCKER #
+# ====== #
+alias dockerip="docker inspect -f '{{range .NetworkSettings.Networks}}{{.IPAddress}} {{end}}'"
+alias dc="docker compose"
+alias dcd="docker compose down"
+alias dcu="docker compose up -d"
+alias dcp="docker compose pull"
+alias dcl="docker compose logs -f"
+alias dps="docker ps --format 'table {{.Names}}\t{{.Status}}\t{{.Ports}}'"
+alias dupdate="dcp && dcd && dcu"
+
+
+# ====== #
+# PODMAN #
+# ====== #
+alias pc="podman compose"
+alias pcu="podman compose up -d"
+alias pcd="podman compose down"
+alias pcp="podman compose pull"
+alias pupdate="pcp && pcd && pcu"

--- a/.config/bash/aliases/devtools.bash
+++ b/.config/bash/aliases/devtools.bash
@@ -1,0 +1,236 @@
+# Prefill an editable command line and run it on Enter. This is the bash
+# stand-in for zsh's `print -z` (which pushes text onto the next prompt buffer);
+# bash can't do that from a normal function, so we read an editable line
+# pre-filled with the command instead.
+__edit_run() {
+    local line
+    read -e -i "$1" -p '❯ ' line || return
+    [[ -n "$line" ]] || return
+    history -s "$line"
+    eval "$line"
+}
+
+
+# ================ #
+# HTTP & API TOOLS #
+# ================ #
+
+# Get headers response
+alias hh='curl -sI'
+
+# Get a JSON response prettily
+curlj() {
+    __ensure_commands curl jq || return 1
+    curl -s "$@" | jq .
+}
+
+# Serve a local directory temporarily
+serve() {
+    if command -v bunx &>/dev/null; then
+        bunx --bun serve --port "${1:-8000}" --dir "${2:-.}"
+    else
+        python3 -m http.server "${1:-8000}"
+    fi
+}
+
+
+
+# ==================== #
+# NODE & BUN WORKFLOWS #
+# ==================== #
+
+# Get a random UUID
+uuid() {
+    if command -v uuidgen &>/dev/null; then
+        uuidgen | tr '[:upper:]' '[:lower:]'
+    elif command -v bun &>/dev/null; then
+        bun -e "import { randomUUID } from \"node:crypto\"; console.log(randomUUID())"
+    else
+        cat /proc/sys/kernel/random/uuid 2>/dev/null || echo "No UUID generator found"
+    fi
+}
+
+# Helper: parse package.json scripts into "name\tcommand" for fzf
+__pick_pkg_script() {
+    __ensure_commands jq fzf || return
+    jq -r '.scripts | to_entries[] | "\(.key)\t\(.value)"' package.json \
+        | fzf --with-nth=1 --delimiter="\t" --preview 'echo -e "\033[1mCommand:\033[0m {2}"'
+}
+
+# Interactively select and RUN a package.json script
+rpkg() {
+    __ensure_commands jq bun fzf || return
+    local script
+    script=$(__pick_pkg_script) || return
+    bun run "${script%%$'\t'*}"
+}
+
+# Interactively select a package.json script and print it to the prompt for
+# editing (add flags, etc.) before running.
+fpkg() {
+    __ensure_commands jq bun fzf || return
+    local script
+    script=$(__pick_pkg_script) || return
+    __edit_run "bun run ${script%%$'\t'*}"
+}
+
+# List package.json scripts
+lspkg() {
+    __ensure_commands jq || return
+    {
+        echo -e "\033[1mSCRIPT\tCOMMAND\033[0m"
+        jq -r '.scripts | to_entries[] | "[\(.key)]\t\(.value)"' package.json
+    } | column -t -s $'\t'
+}
+
+
+
+# ============ #
+# GO WORKFLOWS #
+# ============ #
+
+# Run a go program (targets current dir by default)
+gor() {
+    __ensure_commands go || return
+    go run "${1:-.}"
+}
+
+# Build a go program to ./bin (targets current dir by default)
+gob() {
+    __ensure_commands go || return
+    mkdir -p bin
+    go build -o bin/ "${1:-.}"
+}
+
+# Run a specific test from the current package with an fzf picker
+gotf() {
+    __ensure_commands fzf go || return
+    local test
+    test=$(go test -list . | grep -E '^Test' | fzf) || return
+    go test -run "$test"
+}
+
+# Browse go module dependencies with a "go mod why" preview
+gomodf() {
+    __ensure_commands fzf go || return
+    go list -m all 2>/dev/null | fzf --preview 'go mod why {1}' --preview-window=wrap
+}
+
+
+
+# ====================== #
+# ENVIRONMENT INSPECTION #
+# ====================== #
+
+# Print every path in $PATH on its own line
+paths() {
+    local -a arr
+    IFS=: read -ra arr <<< "$PATH"
+    printf '%s\n' "${arr[@]}"
+}
+
+# Same but with line numbers
+pathsn() {
+    local -a arr
+    IFS=: read -ra arr <<< "$PATH"
+    local i
+    for i in "${!arr[@]}"; do
+        printf '%2d  %s\n' $((i + 1)) "${arr[i]}"
+    done
+}
+
+# Show detailed info about a command, including all paths it appears in
+whichp() {
+    [[ -n "$1" ]] || { echo "Usage: whichp <command>"; return 1; }
+    type -a "$1"
+}
+
+# Show the nearest .env
+envcat() {
+    local dir="$PWD"
+    while [[ "$dir" != "/" ]]; do
+        if [[ -f "$dir/.env" ]]; then
+            cat "$dir/.env"
+            return
+        fi
+        dir=$(dirname "$dir")
+    done
+    echo "No .env file found"
+    return 1
+}
+
+# Search env vars with fzf
+fenv() {
+    __ensure_commands fzf || return
+    printenv | fzf --query="$1"
+}
+
+# Search for a command in $PATH with fzf, then edit/run it
+fcmd() {
+    __ensure_commands fzf || return
+    local cmd
+    cmd=$(compgen -c | sort -u | fzf --query="$1" --preview 'type -a {}' --height=40% --border) || return
+    __edit_run "$cmd"
+}
+
+# Search for an alias with fzf, then edit/run its expansion
+falias() {
+    __ensure_commands fzf || return
+    local cmd
+    cmd=$(alias | sed -E 's/^alias //; s/=/\t/' \
+        | fzf --query="$1" --delimiter="\t" --with-nth=1 \
+              --preview 'echo -e "\033[1mAlias:\033[0m {1}\n\n\033[1mExpands to:\033[0m {2}"' \
+              --preview-window=up:3:wrap) || return
+    __edit_run "${cmd%%$'\t'*}"
+}
+
+# Search for a brew formula/cask with fzf
+fbrew() {
+    __ensure_commands brew fzf || return
+    local cmd
+    cmd=$(brew list | fzf --query="$1" \
+        --preview 'echo -e "\033[1mFormula/Cask:\033[0m {}\n"; HOMEBREW_COLOR=1 brew info {}' --border) || return
+    __edit_run "$cmd"
+}
+
+
+
+# ================== #
+# WORKFLOW UTILITIES #
+# ================== #
+
+command -v hyperfine &>/dev/null && alias hf="hyperfine"
+
+# Pick an emoji from the latest gitmoji list (cached 30 days) with fzf
+emoji() {
+    __ensure_commands fzf || return 1
+    local url='https://git.io/JXXO7'
+    local file
+    file=$(__get_remote_resource "$url" "emojis.txt" "30d")
+    fzf < "$file"
+}
+
+# Gitmoji picker for commit messages.
+# Usage: git commit -m "$(gitmoji) Your commit message"
+gitmoji() {
+    __ensure_commands jq fzf || return 1
+    local url='https://raw.githubusercontent.com/carloscuesta/gitmoji/refs/heads/master/packages/gitmojis/src/gitmojis.json'
+    local file
+    file="$(__get_remote_resource "$url" "gitmojis.json" "30d")"
+
+    jq -r '.gitmojis[] | "\(.emoji)  \(.code)  \(.description)"' "$file" \
+        | fzf --preview 'echo {}' \
+        | awk '{print $1}'
+}
+
+# Get current timestamp in unix and ISO format
+ts() {
+    echo "unix: $(date +%s)"
+    echo "iso:  $(date -Iseconds)"
+}
+
+# Take a screenshot of source to share using silicon
+ssf() {
+    __ensure_commands silicon || return 1
+    silicon "$1" -o "${1%.*}.png"
+}

--- a/.config/bash/aliases/files.bash
+++ b/.config/bash/aliases/files.bash
@@ -1,0 +1,273 @@
+# ================= #
+# LISTING & VIEWING #
+# ================= #
+
+alias ll="ls -lh"
+alias la="ls -ah"
+alias lla="ls -lah"
+alias search="find . -name "
+alias mdv="glow"
+alias jj="jq ."
+
+# If eza is installed, use that instead of ls
+if command -v eza &>/dev/null; then
+    alias ls="eza -h --icons --color=always --hyperlink"
+    alias ld="eza -lh --icons --color=always --only-dirs"
+else
+    alias ls="ls -h --color=always"
+fi
+
+# Replace cat and less with calls to bat
+if command -v bat &>/dev/null; then
+    alias catt="bat"
+    alias cat="bat --paging=never --style=plain"
+    alias less="bat --paging=always"
+fi
+
+# Use erd instead of tree if it's installed
+if command -v erd &>/dev/null; then
+    alias erd="erd --dir-order=last --sort=name --layout=inverted --icons --hidden --no-git"
+    alias tree="erd --level=2"
+fi
+
+# Make sure presenterm uses the kitty protocol for images
+command -v presenterm &>/dev/null && alias presenterm="presenterm --image-protocol=kitty-local"
+
+# Grep with colors by default
+alias grep="grep --color=auto"
+
+# Set nano to whatever editor is
+alias nano="${EDITOR:-nano}"
+
+# Pretty print json files with jq if available
+json() {
+    [[ -f "$1" ]] || { echo "File not found: $1"; return 1; }
+    if command -v jq &>/dev/null; then
+        jq . "$1"
+    else
+        cat "$1"
+    fi
+}
+
+# Pretty print yaml files with yq if available
+yaml() {
+    [[ -f "$1" ]] || { echo "File not found: $1"; return 1; }
+    if command -v yq &>/dev/null; then
+        yq . "$1"
+    else
+        cat "$1"
+    fi
+}
+
+# Hexdump a file with hexdump or xxd
+hex() {
+    [[ -f "$1" ]] || { echo "File not found: $1"; return 1; }
+    if command -v hexdump &>/dev/null; then
+        hexdump "$1"
+    else
+        xxd "$1"
+    fi
+}
+
+# Use fzf to find dirs and cd into them
+zz() {
+    __ensure_commands fzf zoxide || return
+    local dir
+    dir=$(zoxide query -l | fzf) && cd "$dir"
+}
+
+
+
+# =============== #
+# FILE & PATH OPS #
+# =============== #
+
+alias mkdir="mkdir -pv"
+
+# Make a directory and cd into it
+mkcd() {
+    mkdir -p -- "$1" && cd -- "$1"
+}
+
+# Create file and parent directories
+touchd() {
+    mkdir -p "$(dirname "$1")" && touch "$1"
+}
+
+# Move with confirmation and verbose output
+mvf() { mv -iv "$@"; }
+
+# Copy with confirmation and verbose output
+cpf() { cp -iv "$@"; }
+
+# Safely delete to trash first if it exists
+rip() {
+    local t="$1"
+    [[ -z "$t" ]] && { echo "Usage: rip <file|dir>"; return 1; }
+
+    if [[ "$OSTYPE" == darwin* ]]; then
+        mv -vn "$t" ~/.Trash/
+    elif [[ -d "$HOME/.local/share/Trash/files" ]]; then
+        mv -vn "$t" "$HOME/.local/share/Trash/files/"
+    else
+        rm -iv "$t"
+    fi
+}
+
+
+
+# =============== #
+# SEARCH & FILTER #
+# =============== #
+
+command -v fdupes &>/dev/null && alias fdupes="fdupes -r"
+
+# Interactive file content search using ripgrep + fzf.
+#   - Live search as you type
+#   - Ctrl-T toggles ripgrep (content) vs fzf (filename) modes
+#   - Enter opens the file in vim at the matching line
+# Usage: fif <search term>
+fif() {
+    __ensure_commands rg fzf || return
+    if [ ! "$#" -gt 0 ]; then echo "Need a string to search for!"; return 1; fi
+
+    rm -f /tmp/rg-fzf-{r,f}
+    local RG_PREFIX="rg --column --line-number --no-heading --color=always --smart-case "
+    local INITIAL_QUERY="${*:-}"
+
+    fzf --ansi --disabled --query "$INITIAL_QUERY" \
+        --bind "start:reload:$RG_PREFIX {q}" \
+        --bind "change:reload:sleep 0.1; $RG_PREFIX {q} || true" \
+        --bind 'ctrl-t:transform:[[ ! $FZF_PROMPT =~ ripgrep ]] &&
+            echo "rebind(change)+change-prompt(1. ripgrep> )+disable-search+transform-query:echo \{q} > /tmp/rg-fzf-f; cat /tmp/rg-fzf-r" ||
+            echo "unbind(change)+change-prompt(2. fzf> )+enable-search+transform-query:echo \{q} > /tmp/rg-fzf-r; cat /tmp/rg-fzf-f"' \
+        --color "hl:-1:underline,hl+:-1:underline:reverse" \
+        --prompt '1. ripgrep> ' \
+        --delimiter : \
+        --header 'CTRL-T: Switch between ripgrep/fzf' \
+        --preview 'bat --color=always {1} --highlight-line {2}' \
+        --preview-window 'border-left,+{2}+3/3,~3' \
+        --bind 'enter:become(vim {1} +{2})'
+}
+
+# Use fd to find files and pipe to fzf
+ff() {
+    __ensure_commands fd fzf || return
+    fd . | fzf
+}
+
+# Use fd to find files with a given extension and pipe to fzf
+fext() {
+    __ensure_commands fd fzf || return
+    [[ -n "$1" ]] || { echo "Usage: fext <ext>"; return 1; }
+    fd -e "$1" | fzf
+}
+
+
+
+# ==================== #
+# METADATA & TRANSFORM #
+# ==================== #
+
+# Get size of a directory in a human readable format, sorted by size
+fsize() {
+    local DIR="${1:-.}"
+    DIR="$(realpath "$DIR")"
+    echo "Getting size of $DIR"
+    echo ""
+    du -hd 1 "$DIR" | sort -k 1 -n
+}
+
+# Get detailed info about a file or directory
+finfo() {
+    [[ -e "$1" ]] || { echo "File not found: $1"; return 1; }
+    stat "$1"
+}
+
+# Convert a file to a data URL (base64-encoded inline data)
+# Usage: dataurl <file>
+dataurl() {
+    local mimeType
+    mimeType=$(file -b --mime-type "$1")
+    if [[ $mimeType == text/* ]]; then
+        mimeType="${mimeType};charset=utf-8"
+    fi
+    echo "data:${mimeType};base64,$(openssl base64 -in "$1" | tr -d '\n')"
+}
+
+# Count lines in a file
+lines() {
+    [[ -f "$1" ]] || { echo "File not found: $1"; return 1; }
+    wc -l "$1"
+}
+
+# Disk usage of current directory sorted by size
+duh() {
+    du -ah . | sort -h
+}
+
+
+
+# ====================== #
+# ARCHIVING & EXTRACTING #
+# ====================== #
+
+command -v ouch &>/dev/null && alias ou="ouch"
+
+# Extract nearly anything based on file extension.
+# Usage: x archive.tar.gz
+x() {
+    local file="$1"
+    [[ -f "$file" ]] || { echo "No such file: $file" >&2; return 1; }
+    case "$file" in
+        *.tar.bz2)   tar xjf "$file" ;;
+        *.tar.gz)    tar xzf "$file" ;;
+        *.tar.xz)    tar xJf "$file" ;;
+        *.tar.zst)   tar --zstd -xf "$file" ;;
+        *.bz2)       bunzip2 "$file" ;;
+        *.rar)       unrar x "$file" ;;
+        *.gz)        gunzip "$file" ;;
+        *.xz)        xz -d "$file" ;;
+        *.zst)       unzstd "$file" ;;
+        *.lz4)       unlz4 "$file" ;;
+        *.tar)       tar xf "$file" ;;
+        *.tbz2)      tar xjf "$file" ;;
+        *.tgz)       tar xzf "$file" ;;
+        *.zip)       unzip "$file" ;;
+        *.Z)         uncompress "$file" ;;
+        *.7z)        7z x "$file" ;;
+        *)           echo "Don't know how to extract: $file" ;;
+    esac
+}
+
+# Compress nearly anything based on file extension.
+# Usage: c archive.tar.gz files...
+c() {
+    local out="$1"
+    shift
+
+    if [[ -z "$out" || $# -eq 0 ]]; then
+        echo "Usage: c <output.(zip|tar.gz|tar.xz|tar.zst|7z|tar.bz2|gz|xz|zst)> <files...>"
+        return 1
+    fi
+
+    case "$out" in
+        *.tar.gz|*.tgz)   tar -czf "$out" "$@" ;;
+        *.tar.bz2|*.tbz2) tar -cjf "$out" "$@" ;;
+        *.tar.xz)         tar -cJf "$out" "$@" ;;
+        *.tar.zst)        tar --zstd -cf "$out" "$@" ;;
+        *.tar)            tar -cf "$out" "$@" ;;
+        *.zip)            zip -r "$out" "$@" ;;
+        *.7z)             7z a "$out" "$@" ;;
+        *.gz)
+            [[ $# -ne 1 ]] && { echo "Error: .gz compresses only one file"; return 1; }
+            gzip -c "$1" > "$out" ;;
+        *.xz)
+            [[ $# -ne 1 ]] && { echo "Error: .xz compresses only one file"; return 1; }
+            xz -c "$1" > "$out" ;;
+        *.zst)
+            [[ $# -ne 1 ]] && { echo "Error: .zst compresses only one file"; return 1; }
+            zstd -c "$1" > "$out" ;;
+        *) echo "Don't know how to create: $out" ;;
+    esac
+}

--- a/.config/bash/aliases/git.bash
+++ b/.config/bash/aliases/git.bash
@@ -1,0 +1,44 @@
+# ============= #
+# GIT SHORTCUTS #
+# ============= #
+alias gs="git status"
+alias ga="git add"
+alias gp="git pull"
+alias gd="git diff"
+alias gsw="git switch"
+alias gcb="git switch -c"
+alias gcm="git commit -m"
+alias gpu="git push"
+alias gss="git status -s"
+alias gds="git diff --stat"
+
+alias chist='git log --pretty=format:"%Cblue%ci %Creset| %Cgreen%h %Creset| %Cred%an (%cn) %Creset| %s"'
+alias glg="git log --graph --decorate --oneline --all"
+alias glog="git log --oneline"
+
+
+
+# ============= #
+# GIT UTILITIES #
+# ============= #
+
+# Fuzzy find and show git stashes with a diff preview.
+# Usage: fstash
+fstash() {
+    __ensure_commands git fzf || return
+    git stash list --color=always --pretty="%C(brightblack)%gd %C(magenta)%h %>(14)%C(cyan)%cr %C(yellow)%gs" |
+    fzf --ansi --no-sort --tiebreak=index --bind=ctrl-s:toggle-sort \
+        --preview 'git stash show --color=always -p {1}' \
+        --bind "ctrl-m:execute:(git stash show --color=always -p {1})"
+}
+
+# Fuzzy find git commits with a full diff preview.
+# Usage: fshow [git log args]    e.g. fshow origin/main..HEAD
+fshow() {
+    __ensure_commands git fzf || return
+    git log --graph --color=always \
+        --format="%C(auto)%h%d %s %C(black)%C(bold)%cr" "$@" |
+    fzf --ansi --no-sort --reverse --tiebreak=index --bind=ctrl-s:toggle-sort \
+        --preview 'git show --color=always -p $(echo {} | grep -o "[a-f0-9]\{7\}" | head -1)' \
+        --bind 'ctrl-m:execute:(LESS=RSX git -p show --color=always -p $(echo {} | grep -o "[a-f0-9]\{7\}" | head -1))'
+}

--- a/.config/bash/aliases/navigation.bash
+++ b/.config/bash/aliases/navigation.bash
@@ -1,0 +1,103 @@
+# ==================== #
+# SHORTCUTS & DEFAULTS #
+# ==================== #
+
+alias cd..="cd .."
+alias ..="cd .."
+alias ...="cd ../.."
+alias prev='dirs -v'
+alias back="cd -"
+alias cc="clear && cd"
+
+# Use zoxide if it's installed for smarter navigation
+if command -v zoxide &>/dev/null; then
+    alias cd="z"
+fi
+
+# Cd to nearest git root
+cdg() {
+    __ensure_commands git || return
+    local root
+    root=$(git rev-parse --show-toplevel 2>/dev/null) || {
+        echo "Not inside a git repository"
+        return 1
+    }
+    cd "$root"
+}
+
+# Cd to nearest project root (git, npm, go, or cargo)
+cdp() {
+    local markers=(".git" "package.json" "go.mod" "Cargo.toml" "$1")
+    local dir="$PWD" m
+
+    while [[ "$dir" != "/" ]]; do
+        for m in "${markers[@]}"; do
+            [[ -n "$m" && -e "$dir/$m" ]] && { cd "$dir"; return 0; }
+        done
+        dir=$(dirname "$dir")
+    done
+
+    echo "No project root found"
+    return 1
+}
+
+# Cd to nearest parent dir with a given name
+cdup() {
+    [[ -n "$1" ]] || { echo "Usage: cdup <dirname>"; return 1; }
+    local target="$1" dir="$PWD"
+    while [[ "$dir" != "/" ]]; do
+        if [[ "$(basename "$dir")" == "$target" ]]; then
+            cd "$dir"; return 0
+        fi
+        dir=$(dirname "$dir")
+    done
+    echo "No parent directory named '$target' found"
+    return 1
+}
+
+# Cd to directory containing a given file or marker
+cdm() {
+    [[ -n "$1" ]] || { echo "Usage: cdm <marker>"; return 1; }
+    local marker="$1" dir="$PWD"
+    while [[ "$dir" != "/" ]]; do
+        if [[ -e "$dir/$marker" ]]; then
+            cd "$dir"; return 0
+        fi
+        dir=$(dirname "$dir")
+    done
+    echo "No directory containing '$marker' found"
+    return 1
+}
+
+# Cd to a directory selected with fzf, searching from current dir
+cdfz() {
+    __ensure_commands fd fzf || return
+    local dir
+    dir=$(fd -t d . | fzf) || return
+    cd "$dir"
+}
+
+# Cd to the directory of a file
+cdf() {
+    [[ -f "$1" ]] || { echo "File not found: $1"; return 1; }
+    cd "$(dirname "$(realpath "$1")")"
+}
+
+
+
+# ========= #
+# UTILITIES #
+# ========= #
+
+# Wrapper for yazi that changes shell directory when you quit yazi.
+# Usage: yy [directory]
+yy() {
+    __ensure_commands yazi || return 1
+    local tmp cwd
+    tmp="$(mktemp -t "yazi-cwd.XXXXXX")"
+    yazi "$@" --cwd-file="$tmp"
+    if cwd="$(cat -- "$tmp")" && [ -n "$cwd" ] && [ "$cwd" != "$PWD" ]; then
+        builtin cd -- "$cwd"
+    fi
+    rm -f -- "$tmp"
+}

--- a/.config/bash/aliases/system.bash
+++ b/.config/bash/aliases/system.bash
@@ -1,0 +1,92 @@
+# ========== #
+# NETWORKING #
+# ========== #
+
+# HTTP load testing with wrk (requires wrk)
+alias wrk="wrk -t4 -c50 -d10s"
+
+# Get current external ip
+alias myip="curl -s https://ifconfig.me || curl -s https://api.ipify.org"
+
+# What's listening (macOS-friendly)
+listening() {
+    if command -v lsof >/dev/null; then
+        sudo lsof -nP -iTCP -sTCP:LISTEN
+    else
+        ss -tulpn
+    fi
+}
+
+# Default to gping if available, otherwise fallback to ping
+ping() {
+    if command -v gping &>/dev/null; then
+        gping "$@"
+    else
+        command ping "$@"
+    fi
+}
+
+
+
+# =========== #
+# PROCESS OPS #
+# =========== #
+
+# Pick a process to kill
+fkill() {
+    __ensure_commands fzf || return
+    local pid
+    pid=$(ps -ef | sed 1d | fzf -m | awk '{print $2}') || return
+    echo "$pid" | xargs -r kill
+}
+
+
+# =========== #
+# SYSTEM INFO #
+# =========== #
+
+alias mem="ps aux --sort=-%mem | head"
+alias cpu="ps aux --sort=-%cpu | head"
+
+
+
+# ========= #
+# DISK & FS #
+# ========= #
+
+alias dfh="df -h"
+alias watchls="watch -n 1 ls -l"
+alias watchps="watch -n 1 'ps aux | head'"
+command -v gdu-go &>/dev/null && alias gdd="gdu-go --show-disks"
+command -v dua &>/dev/null && alias dua="dua interactive"
+command -v diskonaut &>/dev/null && alias dn="diskonaut"
+
+
+
+# ==== #
+# MISC #
+# ==== #
+
+# Run a command with sudo, but if it's an alias or function, run that instead
+# of the raw command. Bash port of the zsh sdo helper.
+sdo() {
+    local cmd="$1"
+    shift
+
+    case "$(type -t "$cmd")" in
+        function)
+            sudo bash -c "$(declare -f "$cmd"); $cmd \"\$@\"" bash "$@"
+            ;;
+        alias)
+            sudo bash -ic "$(alias "$cmd" | sed -E "s/^alias $cmd='(.*)'\$/\1/") $*"
+            ;;
+        *)
+            sudo "$cmd" "$@"
+            ;;
+    esac
+}
+
+# Use windows desktop 1password-cli if available
+if command -v op.exe &>/dev/null; then
+    alias op="$(command -v op.exe)"
+fi

--- a/.config/bash/bashrc
+++ b/.config/bash/bashrc
@@ -1,0 +1,31 @@
+# ================= #
+# ZerebosSH (bash)  #
+# ================= #
+#
+# Full-featured bash port of the zsh setup, for when zsh isn't available.
+# Mirrors the structure of .config/zsh/.zshrc: load libraries, then plugins,
+# then aliases. Files inside each directory are sourced in filename order
+# (that's why the lib files carry numeric prefixes).
+
+BASH_CONF_DIR="${XDG_CONFIG_HOME:-$HOME/.config}/bash"
+
+# 1. Core libraries (utils, brew, completion, env, options)
+for __f in "$BASH_CONF_DIR"/lib/*.bash; do
+    [[ -r "$__f" ]] && source "$__f"
+done
+
+# 2. Plugins (prompt, suggestions, external tools)
+for __f in "$BASH_CONF_DIR"/plugins/*.bash; do
+    [[ -r "$__f" ]] && source "$__f"
+done
+
+# 3. Aliases and workflows
+for __f in "$BASH_CONF_DIR"/aliases/*.bash; do
+    [[ -r "$__f" ]] && source "$__f"
+done
+unset __f
+
+# Attach ble.sh last, if the suggestions plugin loaded it. ble.sh (inline
+# autosuggestions + syntax highlighting) must attach after everything else has
+# set up its keybindings.
+[[ -n "${BLE_VERSION-}" ]] && ble-attach

--- a/.config/bash/lib/00-utils.bash
+++ b/.config/bash/lib/00-utils.bash
@@ -1,0 +1,63 @@
+# Shared helpers used across the bash config.
+# Ported from the zsh lib/00-utils.zsh (minus the zsh-only zcompile helper).
+
+# Ensure a variable number of commands exist, printing an error if they don't
+#
+# Usage: __ensure_commands <cmd> [...]
+# Returns: 0 if all commands exist, 1 if any are missing (with error message)
+# Example: __ensure_commands git fzf
+__ensure_commands() {
+    [[ $# -gt 0 ]] || { echo "Usage: __ensure_commands <cmd> [...]"; return 1; }
+    local cmd
+    for cmd in "$@"; do
+        if ! command -v "$cmd" &>/dev/null; then
+            echo "Error: Command not found: $cmd"
+            return 1
+        fi
+    done
+}
+
+# Prepend a directory to $PATH only if it exists and isn't already present.
+# This is the bash equivalent of zsh's `path+=(...)` with `typeset -U path`.
+#
+# Usage: __path_prepend <dir> [...]
+__path_prepend() {
+    local dir
+    for dir in "$@"; do
+        [[ -d "$dir" ]] || continue
+        case ":$PATH:" in
+            *":$dir:"*) ;;                 # already present, skip
+            *) PATH="$dir:$PATH" ;;
+        esac
+    done
+}
+
+# Get and cache a remote resource to a local file and return the file path,
+# re-downloading if it's older than a given age (default 7 days)
+#
+# Usage: __get_remote_resource <url> [filename] [max_age]
+#   url      - URL to download from
+#   filename - Optional: Name to save as (defaults to basename of URL)
+#   max_age  - Optional: Cache duration like "7d" (defaults to 7 days)
+#
+# Returns: Prints the path to the cached file
+# Example: source "$(__get_remote_resource "https://example.com/script.sh" "myscript.sh" "30d")"
+__get_remote_resource() {
+    local cache_dir="${XDG_CACHE_HOME:-$HOME/.cache}/bash"
+    [[ -d "$cache_dir" ]] || mkdir -p "$cache_dir"
+
+    local url="$1"
+    local filename="${2:-$(basename "$url")}"
+    local max_age="${3:-7d}"
+    local cache_file="$cache_dir/$filename"
+
+    local days="${max_age%d}"
+    if [[ -f "$cache_file" ]]; then
+        if find "$cache_file" -mtime -"${days}" -print -quit | grep -q .; then
+            echo "$cache_file"
+            return 0
+        fi
+    fi
+    curl -sSL "$url" -o "$cache_file"
+    echo "$cache_file"
+}

--- a/.config/bash/lib/10-brew.bash
+++ b/.config/bash/lib/10-brew.bash
@@ -1,0 +1,30 @@
+# Have homebrew add itself to path if it exists, using a cached shellenv so we
+# don't pay the cost of running `brew shellenv` on every shell startup.
+# Ported from lib/brew.zsh (the fpath bit is zsh-only and dropped here; bash
+# completions are wired up separately in 20-completion.bash).
+__brew_cache_init() {
+    local brew_bin
+    if [[ -x /opt/homebrew/bin/brew ]]; then
+        brew_bin=/opt/homebrew/bin/brew
+    elif [[ -x /home/linuxbrew/.linuxbrew/bin/brew ]]; then
+        brew_bin=/home/linuxbrew/.linuxbrew/bin/brew
+    else
+        return 0
+    fi
+
+    local cache_dir="${XDG_CACHE_HOME:-$HOME/.cache}/shellenv"
+    local cache_file="$cache_dir/brew_shellenv.bash"
+
+    mkdir -p -- "$cache_dir"
+
+    # Rebuild cache if missing or brew binary is newer.
+    # `brew shellenv` output is plain `export` lines, so it works in bash as-is.
+    if [[ ! -f "$cache_file" || "$brew_bin" -nt "$cache_file" ]]; then
+        "$brew_bin" shellenv >| "$cache_file"
+    fi
+
+    source "$cache_file"
+}
+
+__brew_cache_init
+unset -f __brew_cache_init

--- a/.config/bash/lib/20-completion.bash
+++ b/.config/bash/lib/20-completion.bash
@@ -1,0 +1,36 @@
+# Completion setup for bash.
+#
+# zsh's compsys (compinit + zstyle) has no direct bash equivalent, so this
+# approximates the important behaviours from lib/compinit.zsh using the
+# bash-completion package plus readline settings:
+#   - case-insensitive matching
+#   - a navigable menu you can Tab through
+#   - coloured completion lists
+
+# Load bash-completion if it's installed (brew or system paths).
+if ! shopt -oq posix; then
+    if [[ -n "$HOMEBREW_PREFIX" && -r "$HOMEBREW_PREFIX/etc/profile.d/bash_completion.sh" ]]; then
+        source "$HOMEBREW_PREFIX/etc/profile.d/bash_completion.sh"
+    elif [[ -r /usr/share/bash-completion/bash_completion ]]; then
+        source /usr/share/bash-completion/bash_completion
+    elif [[ -r /etc/bash_completion ]]; then
+        source /etc/bash_completion
+    fi
+fi
+
+# Readline behaviour (equivalent-ish to zsh's menu select + case-insensitive
+# matcher-list). `bind` only makes sense in an interactive shell.
+if [[ $- == *i* ]]; then
+    bind 'set completion-ignore-case on'      # typing "foo" matches "Foo"/"FOO"
+    bind 'set completion-map-case on'         # treat - and _ as interchangeable
+    bind 'set show-all-if-ambiguous on'       # one Tab shows all matches
+    bind 'set show-all-if-unmodified on'
+    bind 'set menu-complete-display-prefix on'
+    bind 'set colored-stats on'               # colour matches by file type
+    bind 'set colored-completion-prefix on'
+    bind 'set mark-symlinked-directories on'
+
+    # Tab / Shift-Tab cycle through matches like zsh's `menu select`.
+    bind 'TAB: menu-complete'
+    bind '"\e[Z": menu-complete-backward'
+fi

--- a/.config/bash/lib/30-env.bash
+++ b/.config/bash/lib/30-env.bash
@@ -1,0 +1,42 @@
+# Environment variables and $PATH setup.
+# Ported from .zshenv + lib/env.zsh. Bash has no .zshenv equivalent that is
+# guaranteed to run for interactive shells, so the XDG vars live here too.
+
+# XDG base directories (normally set by .zshenv for zsh)
+export XDG_CONFIG_HOME="${XDG_CONFIG_HOME:-$HOME/.config}"
+export XDG_DATA_HOME="${XDG_DATA_HOME:-$HOME/.local/share}"
+export XDG_CACHE_HOME="${XDG_CACHE_HOME:-$HOME/.cache}"
+
+export LC_ALL="${LC_ALL:-en_US.UTF-8}"
+
+# Alias python -> python3 if only python3 exists (mirrors .zshenv)
+if command -v python3 &>/dev/null && ! command -v python &>/dev/null; then
+    alias python="python3"
+fi
+
+# Add important paths to $PATH (dedup + existence checked by the helper).
+# Prepend in reverse of desired priority so $HOME/bin ends up first.
+__path_prepend "$HOME/go/bin" "$HOME/.local/bin" "$HOME/bin"
+export PATH
+
+# Preferred editor: flow (flow-control) > micro > nano
+if command -v flow &>/dev/null; then
+    export EDITOR="flow"
+elif command -v micro &>/dev/null; then
+    export EDITOR="micro"
+fi
+
+export MICRO_TRUECOLOR=1          # force truecolor for micro
+export DIRENV_LOG_FORMAT=''       # silence direnv output
+export DISABLE_AUTO_TITLE="false" # ensure autotitle is enabled
+export DELTA_PAGER="less --mouse" # force mouse support in delta
+
+# Make the terminal title show the current directory when using Tabby terminal
+# (bash port of the zsh precmd hook via PROMPT_COMMAND).
+if [[ "$TERM_PROGRAM" == "Tabby" ]]; then
+    __tabby_title() { printf '\e]2;%s\a' "${PWD/#$HOME/~}"; }
+    case "$PROMPT_COMMAND" in
+        *__tabby_title*) ;;
+        *) PROMPT_COMMAND="__tabby_title${PROMPT_COMMAND:+; $PROMPT_COMMAND}" ;;
+    esac
+fi

--- a/.config/bash/lib/40-options.bash
+++ b/.config/bash/lib/40-options.bash
@@ -1,0 +1,53 @@
+# Shell options, history, and keybindings.
+# Ported from lib/options.zsh using bash's shopt / set / HISTCONTROL.
+
+# --- History ---------------------------------------------------------------
+[[ -d "$XDG_DATA_HOME/bash" ]] || mkdir -p "$XDG_DATA_HOME/bash"
+export HISTFILE="$XDG_DATA_HOME/bash/history"
+export HISTSIZE=10000          # entries kept in memory
+export HISTFILESIZE=10000      # entries kept on disk (zsh SAVEHIST equivalent)
+
+# ignoreboth = ignorespace (leading-space commands not stored) + ignoredups
+# erasedups  = drop older duplicates of the current command
+export HISTCONTROL=ignoreboth:erasedups
+export HISTTIMEFORMAT='%F %T '  # timestamp history entries
+
+shopt -s histappend            # append instead of overwriting on exit
+shopt -s cmdhist               # keep multi-line commands as one entry
+shopt -s lithist               # ...preserving embedded newlines
+
+# Write each command to the history file immediately so new shells see it
+# (bash equivalent of zsh's INC_APPEND_HISTORY). Prepended so it doesn't
+# clobber any PROMPT_COMMAND set earlier (e.g. the Tabby title hook).
+case "$PROMPT_COMMAND" in
+    *'history -a'*) ;;
+    *) PROMPT_COMMAND="history -a${PROMPT_COMMAND:+; $PROMPT_COMMAND}" ;;
+esac
+
+# --- Behaviour (bash analogues of the zsh setopts) -------------------------
+shopt -s autocd 2>/dev/null    # 'foo' becomes 'cd foo' if it's a directory
+shopt -s cdspell               # autocorrect minor typos in `cd` paths (~CORRECT)
+shopt -s dirspell 2>/dev/null
+shopt -s extglob               # advanced globbing: !(), @(), +(), etc.
+shopt -s globstar              # ** matches across directories (EXTENDED_GLOB)
+shopt -s nocaseglob            # case-insensitive globbing
+shopt -s checkwinsize          # keep $LINES/$COLUMNS correct after resize
+set -o noclobber               # '>' won't clobber files; use >| to force
+set -o pipefail                # a pipeline fails if any stage fails
+# (INTERACTIVE_COMMENTS is on by default for interactive bash.)
+
+# --- Keybindings -----------------------------------------------------------
+if [[ $- == *i* ]]; then
+    # Prefix history search: type part of a command, then Up/Down walks through
+    # only the matching history entries. This is the zero-dependency cousin of
+    # autosuggestions and works in every bash.
+    bind '"\e[A": history-search-backward'
+    bind '"\e[B": history-search-forward'
+    bind '"\eOA": history-search-backward'   # some terminals send SS3
+    bind '"\eOB": history-search-forward'
+
+    # Consistent Home / End / Delete (mirrors options.zsh)
+    bind '"\e[H": beginning-of-line'
+    bind '"\e[F": end-of-line'
+    bind '"\e[3~": delete-char'
+fi

--- a/.config/bash/plugins/10-prompt.bash
+++ b/.config/bash/plugins/10-prompt.bash
@@ -1,0 +1,43 @@
+# Prompt.
+#
+# Powerlevel10k is zsh-only, so there is no way to get a true 1:1 port. The
+# closest cross-shell match to the p10k look is Starship (which the fish config
+# in this repo already uses), so prefer it when available and fall back to a
+# hand-rolled, git-aware two-line prompt otherwise.
+
+[[ $- == *i* ]] || return 0
+
+if command -v starship &>/dev/null; then
+    eval "$(starship init bash)"
+    return 0
+fi
+
+# --- Fallback prompt -------------------------------------------------------
+# A tiny git-aware two-line prompt: context on top, prompt symbol below. The
+# branch is computed as plain text and coloured directly in PS1, with colours
+# wrapped in \[ \] so bash measures the prompt width correctly. (We deliberately
+# don't route the branch through __git_ps1 + printf, which would mangle the
+# \[ \] non-printing markers.)
+
+__prompt_command() {
+    local exit=$?
+
+    local reset='\[\e[0m\]' blue='\[\e[34m\]' green='\[\e[32m\]'
+    local red='\[\e[31m\]' magenta='\[\e[35m\]'
+
+    # Exit-status indicator: green symbol on success, red with code on failure
+    local status_seg="${green}❯${reset}"
+    [[ $exit -ne 0 ]] && status_seg="${red}❯ ${exit}${reset}"
+
+    # Git segment: branch (or short SHA when detached) plus a * when dirty
+    local branch dirty="" git_seg=""
+    branch=$(git symbolic-ref --short HEAD 2>/dev/null || git rev-parse --short HEAD 2>/dev/null)
+    if [[ -n "$branch" ]]; then
+        git diff --quiet --ignore-submodules HEAD 2>/dev/null || dirty="*"
+        git_seg=" ${magenta}⌥ ${branch}${dirty}${reset}"
+    fi
+
+    PS1="${blue}\w${reset}${git_seg}\n${status_seg} "
+}
+
+PROMPT_COMMAND="__prompt_command${PROMPT_COMMAND:+; $PROMPT_COMMAND}"

--- a/.config/bash/plugins/20-suggestions.bash
+++ b/.config/bash/plugins/20-suggestions.bash
@@ -1,0 +1,29 @@
+# Autosuggestions + syntax highlighting for bash.
+#
+# zsh gets these from zsh-autosuggestions and fast-syntax-highlighting. The
+# bash-world equivalent is ble.sh (https://github.com/akinomyoga/ble.sh), which
+# provides BOTH inline history autosuggestions and syntax highlighting in one
+# package. We source it if it's installed rather than cloning anything.
+#
+# Install it once with:
+#   git clone --recursive --depth 1 https://github.com/akinomyoga/ble.sh ~/.local/share/blesh-src
+#   make -C ~/.local/share/blesh-src install PREFIX=~/.local
+#
+# Note: ble.sh must be sourced near the TOP of an interactive rc to attach,
+# with a matching `ble-attach` at the very end. The main bashrc handles the
+# attach; here we only source the library.
+
+[[ $- == *i* ]] || return 0
+
+for __ble in \
+    "$XDG_DATA_HOME/blesh/ble.sh" \
+    "$HOME/.local/share/blesh/ble.sh" \
+    "$HOMEBREW_PREFIX/share/blesh/ble.sh"; do
+    if [[ -r "$__ble" ]]; then
+        source "$__ble" --attach=none
+        # Style the suggestion to match zsh-autosuggestions' dim grey ghost text.
+        declare -F bleopt &>/dev/null && bleopt auto_complete_face='fg=242'
+        break
+    fi
+done
+unset __ble

--- a/.config/bash/plugins/30-external.bash
+++ b/.config/bash/plugins/30-external.bash
@@ -1,0 +1,69 @@
+# External tool integrations: fzf, zoxide, direnv.
+# Ported from plugins/external.zsh — these tools are all shell-agnostic.
+
+# Set theming for the fzf window (identical to the zsh config)
+export FZF_DEFAULT_OPTS='
+    --color=preview-fg:-1,preview-bg:-1
+    --color=fg:-1,fg+:#f8f8f8,bg:-1,bg+:#383838
+    --color=hl:red,hl+:red,info:green,marker:blue
+    --color=prompt:blue,spinner:magenta,pointer:blue
+    --color=border:#383838,separator:green
+    --scrollbar="█"
+    --pointer="█"
+    --marker="►"
+    --prompt="↪ "
+    --border="rounded"
+    --preview-window="border-rounded"'
+
+# Use fd or rg for fzf file searching if available, with sensible defaults
+if command -v fd >/dev/null; then
+    export FZF_DEFAULT_COMMAND='fd --type f --hidden --exclude .git'
+    export FZF_CTRL_T_COMMAND="$FZF_DEFAULT_COMMAND"
+    export FZF_ALT_C_COMMAND='fd --type d --hidden --exclude .git'
+elif command -v rg >/dev/null; then
+    export FZF_DEFAULT_COMMAND='rg --files --hidden --glob "!.git"'
+    export FZF_CTRL_T_COMMAND="$FZF_DEFAULT_COMMAND"
+fi
+
+# Enable fzf keybindings (Ctrl-R history, Ctrl-T files, Alt-C cd) and completion.
+# Modern fzf ships `fzf --bash`; fall back to the packaged shell scripts for
+# older versions.
+if command -v fzf &>/dev/null; then
+    __fzf_loaded=0
+    if fzf --bash &>/dev/null; then
+        eval "$(fzf --bash)"
+        __fzf_loaded=1
+    else
+        for __d in "$HOMEBREW_PREFIX/opt/fzf/shell" /usr/local/opt/fzf/shell \
+                   /usr/share/fzf /usr/share/fzf/shell /usr/share/doc/fzf/examples \
+                   "$HOME/.fzf/shell"; do
+            if [[ -r "$__d/key-bindings.bash" ]]; then
+                source "$__d/key-bindings.bash"
+                [[ -r "$__d/completion.bash" ]] && source "$__d/completion.bash"
+                __fzf_loaded=1
+                break
+            fi
+        done
+        unset __d
+    fi
+
+    # Fallback for minimal machines that ship fzf without its shell integration:
+    # a small Ctrl-R history menu so the searchable history always works.
+    if [[ $__fzf_loaded -eq 0 && $- == *i* ]]; then
+        __fzf_history_widget() {
+            local line
+            line=$(HISTTIMEFORMAT='' history | fzf --tac --no-sort --query="$READLINE_LINE" +m |
+                   sed -E 's/^[[:space:]]*[0-9]+[[:space:]]+//')
+            READLINE_LINE="$line"
+            READLINE_POINT=${#READLINE_LINE}
+        }
+        bind -x '"\C-r": __fzf_history_widget'
+    fi
+    unset __fzf_loaded
+fi
+
+# Hook zoxide if installed (provides `z` / `zi`)
+command -v zoxide &>/dev/null && eval "$(zoxide init bash)"
+
+# Hook direnv if installed
+command -v direnv &>/dev/null && eval "$(direnv hook bash)"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,28 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## [Unreleased]
 
+### Added
+- Full **bash port** of the zsh setup under `.config/bash/`, mirroring the
+  `lib/` / `plugins/` / `aliases/` layout:
+  - Ported aliases and workflow functions (git, files, navigation, devtools,
+    containers, system) with bash-native equivalents where zsh idioms don't
+    translate (`print -z` → editable read, `path` array → dedup helper, etc.)
+  - Cached `brew shellenv`, XDG paths, history, and readline/completion tuning
+  - fzf / zoxide / direnv integration
+  - Git-aware prompt (Starship if present, hand-rolled fallback) and optional
+    ble.sh inline autosuggestions + syntax highlighting
+  - Top-level `.bashrc` / `.bash_profile` entry points (login-shell safe)
+- Shareable **slim common base** under `slim/` for onboarding coworkers:
+  - Self-contained `base.bash` and `base.zsh` (no background cloning/installing)
+  - Ctrl-R fuzzy history (fzf), history autosuggestions, git-aware prompt,
+    sensible history, and a curated alias set — all degrading gracefully
+  - `slimhelp` feature-status helper, idempotent `install.sh`, and a guided
+    walkthrough `README.md`
+
+### Changed
+- README documents bash support and the slim base; repo positioned as
+  "zsh-first" rather than "zsh-only"
+
 ## [2.1.0] - 2026-03-05
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -152,11 +152,16 @@ Replacements for traditional Unix commands:
 ```
 dotfiles/
 ├── .config/
-│   ├── zsh/              # ZSH configuration
+│   ├── zsh/              # ZSH configuration (primary)
 │   │   ├── .zshrc        # Main config file
 │   │   ├── lib/          # Core libraries
 │   │   ├── aliases/      # Categorized aliases
 │   │   └── plugins/      # Plugin configurations
+│   ├── bash/             # Full bash port of the zsh setup (see below)
+│   │   ├── bashrc        # Main loader
+│   │   ├── lib/          # Core libraries
+│   │   ├── aliases/      # Categorized aliases
+│   │   └── plugins/      # Prompt, suggestions, external tools
 │   ├── yadm/             # YADM-specific configs
 │   │   ├── bootstrap     # Auto-setup script
 │   │   └── brewfiles/    # Homebrew bundles
@@ -168,7 +173,10 @@ dotfiles/
 │   ├── yazi/             # Yazi file manager config
 │   ├── micro/            # Micro editor config
 │   └── ...               # Other app configs
+├── slim/                 # Shareable "common base" for coworkers (bash + zsh)
 ├── bin/                  # Custom scripts
+├── .bashrc              # Bash entry point (sources .config/bash)
+├── .bash_profile        # Login-shell entry point (sources .bashrc)
 └── .zshenv               # ZSH environment setup
 ```
 
@@ -212,6 +220,46 @@ dotfiles/
 - `gdd` - Show disk usage
 - `btm` - Display system information
 - `listening` - Show open ports
+
+## 🐚 Bash Support
+
+While this setup is zsh-first, there is a full **bash port** under
+[`.config/bash/`](.config/bash/) for the times you're dropped into a machine
+without zsh. It mirrors the zsh layout (`lib/`, `plugins/`, `aliases/`) and
+ports as much as bash allows:
+
+- Same aliases and workflow functions (`gs`, `fshow`, `fif`, `x`/`c`, `mkcd`,
+  the Go/Node helpers, etc.)
+- fzf, zoxide, and direnv integration
+- Cached `brew shellenv`, XDG paths, history, and completion tuning
+- A git-aware prompt (uses [Starship](https://starship.rs/) if installed, with
+  a hand-rolled fallback) in place of Powerlevel10k
+- Inline autosuggestions + syntax highlighting via
+  [ble.sh](https://github.com/akinomyoga/ble.sh) when it's installed
+
+It loads through the top-level `.bashrc` (with `.bash_profile` sourcing it for
+login shells). Where a zsh feature has no bash equivalent, the closest
+practical substitute is used and noted in comments.
+
+## 🤝 A Slim Base to Share
+
+Want to hand a colleague a sane shell without the full setup? The
+[`slim/`](slim/) directory is a self-contained "common base" — a curated slice
+that's useful without being overwhelming, and that **never clones or installs
+anything behind your back**.
+
+- One file per shell: [`slim/base.bash`](slim/base.bash) and
+  [`slim/base.zsh`](slim/base.zsh)
+- Headline features: <kbd>Ctrl</kbd>+<kbd>R</kbd> fuzzy history (via fzf) and
+  history autosuggestions, plus a git-aware prompt, good history defaults, and
+  a tasteful alias set
+- Everything optional degrades gracefully; `slimhelp` shows what's active and
+  what to install next
+- A guided [`slim/README.md`](slim/README.md) and an idempotent
+  [`slim/install.sh`](slim/install.sh) make onboarding a one-liner
+
+Point someone at [`slim/`](slim/) and they can adopt it by adding a single
+`source` line to their rc.
 
 ## 🎨 Customization
 
@@ -347,4 +395,7 @@ Built with and inspired by:
 
 ---
 
-**Note**: This is a ZSH-specific configuration. While some tools and configs work across shells, the core shell configuration requires ZSH. Review and customize before using.
+**Note**: This is a ZSH-first configuration — the primary, most polished setup
+targets ZSH. A full bash port lives in [`.config/bash/`](.config/bash/), and a
+shareable common base for both shells lives in [`slim/`](slim/). Review and
+customize before using.

--- a/slim/README.md
+++ b/slim/README.md
@@ -1,0 +1,163 @@
+# Slim shell base
+
+A small, friendly starting point for anyone who lives in the terminal but has
+never set up a shell config. It's a curated slice of a much larger personal
+[dotfiles setup](../README.md) — just the broadly useful parts, with none of
+the machinery that only makes sense for one person's machine.
+
+**No magic.** It won't clone repositories in the background, install packages,
+or take over your shell. It's one file you `source`. Delete one line to undo it.
+
+Works with **bash** and **zsh** — pick the file that matches your shell.
+
+---
+
+## What you get
+
+Out of the box, with zero extra installs:
+
+- **Reachable history** — type the start of a command and press <kbd>↑</kbd> to
+  cycle through just the matching past commands.
+- **A case-insensitive completion menu** — <kbd>Tab</kbd> through matches; `foo`
+  finds `Foo`.
+- **A clean, git-aware prompt** — shows your directory and current branch.
+- **Sensible history** — bigger, de-duplicated, shared between open shells.
+- **A handful of aliases** you'll actually use (`gs`, `ll`, `..`, `mkcd`,
+  `extract`, and friends).
+
+Install a few small tools and it lights up further (all optional):
+
+- **[`fzf`](https://github.com/junegunn/fzf)** → <kbd>Ctrl</kbd>+<kbd>R</kbd>
+  opens a **live, searchable menu of your command history**, plus
+  <kbd>Ctrl</kbd>+<kbd>T</kbd> (files) and <kbd>Alt</kbd>+<kbd>C</kbd> (cd).
+- **[`zsh-autosuggestions`](https://github.com/zsh-users/zsh-autosuggestions)**
+  (zsh) or **[`ble.sh`](https://github.com/akinomyoga/ble.sh)** (bash) → grey
+  **"ghost text"** predicting your command from history as you type.
+- **[`zoxide`](https://github.com/ajeetdsouza/zoxide)** → `z <partial-name>` to
+  jump to directories you visit often.
+- **[`eza`](https://github.com/eza-community/eza)** / **[`bat`](https://github.com/sharkdp/bat)**
+  → prettier `ls` and `cat`.
+
+Run **`slimhelp`** at any time to see what's active and what to install next.
+
+---
+
+## Install
+
+### The quick way
+
+From this folder:
+
+```sh
+./install.sh          # auto-detects bash or zsh from your $SHELL
+```
+
+That adds a single guarded line to your `~/.bashrc` or `~/.zshrc` (and, on
+macOS, makes sure `~/.bash_profile` loads your `~/.bashrc`). Re-running is safe.
+
+Then open a new terminal — or reload the current one:
+
+```sh
+exec $SHELL
+```
+
+### The manual way (if you'd rather see exactly what changes)
+
+You only ever add **one line**. Point it at whichever file matches your shell.
+
+**bash** — add to the end of `~/.bashrc`:
+
+```bash
+[ -r "/path/to/slim/base.bash" ] && . "/path/to/slim/base.bash"
+```
+
+> On macOS, new Terminal windows are *login* shells and read `~/.bash_profile`
+> instead of `~/.bashrc`. If you don't already have a `~/.bash_profile`, create
+> one with this line so your `~/.bashrc` actually loads:
+> ```bash
+> [ -r ~/.bashrc ] && . ~/.bashrc
+> ```
+
+**zsh** — add to the end of `~/.zshrc`:
+
+```zsh
+[ -r "/path/to/slim/base.zsh" ] && . "/path/to/slim/base.zsh"
+```
+
+Replace `/path/to/slim` with wherever you saved this folder. Reload with
+`exec $SHELL` and you're done.
+
+### Don't have this folder locally?
+
+Grab just the one file for your shell. For example, with `curl`:
+
+```sh
+mkdir -p ~/.config/slim
+curl -fsSL <raw-url-to>/base.bash -o ~/.config/slim/base.bash   # or base.zsh
+```
+
+Then add the matching `source` line above, pointing at
+`~/.config/slim/base.bash`.
+
+---
+
+## Unlocking the optional tools
+
+Install as many or as few as you like — the base adapts to whatever is present.
+
+**macOS** (with [Homebrew](https://brew.sh)):
+
+```sh
+brew install fzf zoxide eza bat
+brew install zsh-autosuggestions        # zsh users, for ghost text
+```
+
+**Debian / Ubuntu:**
+
+```sh
+sudo apt install fzf zoxide eza bat
+sudo apt install zsh-autosuggestions    # zsh users, for ghost text
+```
+
+**bash ghost text** uses [`ble.sh`](https://github.com/akinomyoga/ble.sh),
+which also adds syntax highlighting. One-time setup:
+
+```sh
+git clone --recursive --depth 1 https://github.com/akinomyoga/ble.sh ~/.local/share/blesh-src
+make -C ~/.local/share/blesh-src install PREFIX=~/.local
+```
+
+Open a new shell after installing anything, then run `slimhelp` to confirm.
+
+---
+
+## Making it your own
+
+- **Add your own aliases and functions:** put them *after* the `source` line in
+  your `~/.bashrc` / `~/.zshrc`. Anything there wins.
+- **Don't like an alias?** `unalias name` after the source line, or just
+  override it with your own definition.
+- **Want the prompt gone?** Set your own `PS1`/`PROMPT` after the source line.
+
+## Uninstalling
+
+Delete the `# >>> slim base >>>` … `# <<< slim base <<<` block from your
+`~/.bashrc` / `~/.zshrc` (and `~/.bash_profile` if present), or just remove the
+single `source` line you added manually. Nothing else was touched.
+
+---
+
+## FAQ
+
+**Is this going to slow down my shell?** No. It's a single small file with no
+network calls; optional integrations only run if the tool is installed.
+
+**Will it change how my commands behave?** It's intentionally conservative. It
+doesn't enable spelling autocorrect prompts, doesn't block `>` overwrites, and
+doesn't replace `cd`. The riskiest thing it does is make `ls`/`cat` prettier
+*when* `eza`/`bat` are installed.
+
+**Can I see the full setup this came from?** Yes — the
+[parent dotfiles repo](../README.md) has the complete, zsh-first configuration
+(themed prompt, more tools, terminal configs, and a bootstrap installer). This
+slim base is the "just the good bits" version meant to be easy to adopt.

--- a/slim/base.bash
+++ b/slim/base.bash
@@ -1,0 +1,253 @@
+# ============================================================== #
+#  Slim bash base — a friendly starting point for a raw bash shell #
+# ============================================================== #
+#
+# A small, self-contained slice of a much larger dotfiles setup. It gives you
+# the good parts (fuzzy history search, a git-aware prompt, sensible defaults,
+# a handful of aliases, optional ghost-text suggestions) without cloning
+# anything in the background or taking over your machine.
+#
+# Everything here degrades gracefully: if an optional tool isn't installed,
+# the related feature is quietly skipped. Run `slimhelp` any time to see what's
+# active and what you can install to unlock more.
+#
+# Install: see this folder's README.md (one line added to your ~/.bashrc).
+
+# Only do anything for interactive shells.
+case $- in *i*) ;; *) return ;; esac
+
+
+# --------------------------------------------------------------------------- #
+# History — remember more, remember it well
+# --------------------------------------------------------------------------- #
+HISTFILE="${HISTFILE:-$HOME/.bash_history}"
+HISTSIZE=10000
+HISTFILESIZE=10000
+HISTCONTROL=ignoreboth:erasedups   # ignore dupes + leading-space commands
+shopt -s histappend                # append instead of overwriting on exit
+# Write each command as you run it so new shells see it (multi-shell friendly)
+case "$PROMPT_COMMAND" in
+    *'history -a'*) ;;
+    *) PROMPT_COMMAND="history -a${PROMPT_COMMAND:+; $PROMPT_COMMAND}" ;;
+esac
+
+
+# --------------------------------------------------------------------------- #
+# Sensible interactive behaviour
+# --------------------------------------------------------------------------- #
+shopt -s autocd 2>/dev/null        # type a directory name to cd into it
+shopt -s cdspell 2>/dev/null       # autocorrect small typos in cd paths
+shopt -s checkwinsize              # keep $LINES/$COLUMNS right after a resize
+shopt -s globstar 2>/dev/null      # ** matches across directories
+
+
+# --------------------------------------------------------------------------- #
+# Completion + keys — a case-insensitive menu and reachable history
+# --------------------------------------------------------------------------- #
+# Load bash-completion if present (brew or system paths)
+if [[ -n "$HOMEBREW_PREFIX" && -r "$HOMEBREW_PREFIX/etc/profile.d/bash_completion.sh" ]]; then
+    source "$HOMEBREW_PREFIX/etc/profile.d/bash_completion.sh"
+elif [[ -r /usr/share/bash-completion/bash_completion ]]; then
+    source /usr/share/bash-completion/bash_completion
+elif [[ -r /etc/bash_completion ]]; then
+    source /etc/bash_completion
+fi
+
+bind 'set completion-ignore-case on'   # typing "foo" matches "Foo"/"FOO"
+bind 'set show-all-if-ambiguous on'    # one Tab reveals all matches
+bind 'set colored-stats on'            # colour completions by file type
+bind 'TAB: menu-complete'              # Tab cycles through matches
+bind '"\e[Z": menu-complete-backward'  # Shift-Tab cycles backward
+
+# Type the start of a command, then press Up: you cycle through only the
+# history entries that begin with what you typed. The zero-install cousin of
+# autosuggestions, and it works in every bash.
+bind '"\e[A": history-search-backward'
+bind '"\e[B": history-search-forward'
+bind '"\eOA": history-search-backward'
+bind '"\eOB": history-search-forward'
+
+
+# --------------------------------------------------------------------------- #
+# fzf — the Ctrl-R searchable history menu (and more)
+# --------------------------------------------------------------------------- #
+# With fzf installed you get:
+#   Ctrl-R  fuzzy-search your command history in a live menu
+#   Ctrl-T  fuzzy-pick a file path into the current command
+#   Alt-C   fuzzy-cd into a subdirectory
+if command -v fzf &>/dev/null; then
+    _fzf_loaded=0
+    if fzf --bash &>/dev/null; then
+        # Modern fzf (>= 0.48): generate the integration inline, no files needed.
+        eval "$(fzf --bash)"
+        _fzf_loaded=1
+    else
+        for _d in "$HOMEBREW_PREFIX/opt/fzf/shell" /usr/local/opt/fzf/shell \
+                  /usr/share/fzf /usr/share/fzf/shell /usr/share/doc/fzf/examples \
+                  "$HOME/.fzf/shell"; do
+            if [[ -r "$_d/key-bindings.bash" ]]; then
+                source "$_d/key-bindings.bash"
+                [[ -r "$_d/completion.bash" ]] && source "$_d/completion.bash"
+                _fzf_loaded=1
+                break
+            fi
+        done
+        unset _d
+    fi
+
+    # Ultimate fallback: fzf is installed but its official Ctrl-R integration
+    # wasn't found (some minimal distros don't ship it). Wire up a small history
+    # widget ourselves so the searchable menu always works.
+    if [[ $_fzf_loaded -eq 0 ]]; then
+        __fzf_history_slim() {
+            local line
+            line=$(HISTTIMEFORMAT='' history | fzf --tac --no-sort --query="$READLINE_LINE" +m |
+                   sed -E 's/^[[:space:]]*[0-9]+[[:space:]]+//')
+            READLINE_LINE="$line"
+            READLINE_POINT=${#READLINE_LINE}
+        }
+        bind -x '"\C-r": __fzf_history_slim'
+    fi
+    unset _fzf_loaded
+fi
+
+
+# --------------------------------------------------------------------------- #
+# zoxide — a smarter cd that learns your habits (optional, `z <partial-name>`)
+# --------------------------------------------------------------------------- #
+command -v zoxide &>/dev/null && eval "$(zoxide init bash)"
+
+
+# --------------------------------------------------------------------------- #
+# A clean, git-aware prompt (no theme engine required)
+# --------------------------------------------------------------------------- #
+__slim_git_branch() {
+    local branch
+    branch=$(git symbolic-ref --short HEAD 2>/dev/null) || return
+    printf ' \001\e[35m\002⌥ %s\001\e[0m\002' "$branch"
+}
+
+__slim_prompt() {
+    local exit=$?
+    local reset='\[\e[0m\]' blue='\[\e[34m\]' green='\[\e[32m\]' red='\[\e[31m\]'
+    local sym="${green}❯${reset}"
+    [[ $exit -ne 0 ]] && sym="${red}❯${reset}"
+    PS1="${blue}\w${reset}\$(__slim_git_branch)\n${sym} "
+}
+# Prepend so we don't clobber the `history -a` set above.
+PROMPT_COMMAND="__slim_prompt${PROMPT_COMMAND:+; $PROMPT_COMMAND}"
+
+
+# --------------------------------------------------------------------------- #
+# Autosuggestions + syntax highlighting via ble.sh (optional)
+# --------------------------------------------------------------------------- #
+# bash's answer to zsh-autosuggestions is ble.sh, which adds BOTH grey ghost
+# text AND syntax highlighting. We source it only if you've installed it; we
+# never fetch it for you. To set it up once:
+#   git clone --recursive --depth 1 https://github.com/akinomyoga/ble.sh ~/.local/share/blesh-src
+#   make -C ~/.local/share/blesh-src install PREFIX=~/.local
+for _ble in "$HOME/.local/share/blesh/ble.sh" \
+            "${XDG_DATA_HOME:-$HOME/.local/share}/blesh/ble.sh" \
+            "$HOMEBREW_PREFIX/share/blesh/ble.sh"; do
+    if [[ -r "$_ble" ]]; then
+        source "$_ble"
+        break
+    fi
+done
+unset _ble
+
+
+# --------------------------------------------------------------------------- #
+# A small, tasteful set of aliases
+# --------------------------------------------------------------------------- #
+# Navigation
+alias ..="cd .."
+alias ...="cd ../.."
+
+# Listing — use eza if it's around, otherwise plain ls with colour
+if command -v eza &>/dev/null; then
+    alias ls="eza --icons --color=always --group-directories-first"
+else
+    alias ls="ls --color=auto"
+fi
+alias ll="ls -lh"
+alias la="ls -a"
+alias lla="ls -lah"
+
+# Nicer cat via bat, if installed (Debian/Ubuntu ship it as `batcat`)
+if command -v bat &>/dev/null; then
+    alias cat="bat --paging=never --style=plain"
+elif command -v batcat &>/dev/null; then
+    alias cat="batcat --paging=never --style=plain"
+fi
+
+# Colourful grep
+alias grep="grep --color=auto"
+
+# Git shortcuts (the ones you'll actually type all day)
+alias gs="git status"
+alias ga="git add"
+alias gp="git pull"
+alias gd="git diff"
+alias gcm="git commit -m"
+alias gpu="git push"
+alias glog="git log --oneline"
+alias glg="git log --graph --decorate --oneline --all"
+
+# Make a directory and cd into it in one go
+mkcd() { mkdir -p -- "$1" && cd -- "$1"; }
+
+# Extract almost any archive by extension: `extract file.tar.gz`
+extract() {
+    [[ -f "$1" ]] || { echo "No such file: $1"; return 1; }
+    case "$1" in
+        *.tar.bz2|*.tbz2) tar xjf "$1" ;;
+        *.tar.gz|*.tgz)   tar xzf "$1" ;;
+        *.tar.xz)         tar xJf "$1" ;;
+        *.tar.zst)        tar --zstd -xf "$1" ;;
+        *.tar)            tar xf  "$1" ;;
+        *.bz2)            bunzip2 "$1" ;;
+        *.gz)             gunzip  "$1" ;;
+        *.xz)             xz -d   "$1" ;;
+        *.zip)            unzip   "$1" ;;
+        *.7z)             7z x    "$1" ;;
+        *.rar)            unrar x "$1" ;;
+        *) echo "Don't know how to extract: $1" ;;
+    esac
+}
+
+# Show your current public IP
+alias myip="curl -s https://ifconfig.me || curl -s https://api.ipify.org"
+
+
+# --------------------------------------------------------------------------- #
+# slimhelp — what's on, and how to unlock the rest
+# --------------------------------------------------------------------------- #
+slimhelp() {
+    local ok=$'\033[32m✓\033[0m' no=$'\033[31m✗\033[0m'
+    _has() { command -v "$1" &>/dev/null && printf '%s' "$ok" || printf '%s' "$no"; }
+
+    printf '\033[1mSlim bash base\033[0m — feature status\n\n'
+    printf '  Always on:\n'
+    printf '    • Up-arrow prefix history search (type, then press Up)\n'
+    printf '    • Case-insensitive Tab-completion menu\n'
+    printf '    • Git-aware prompt, sensible history, handy aliases\n\n'
+    printf '  Optional tools (install to unlock more):\n'
+    printf '    %s fzf     Ctrl-R fuzzy history, Ctrl-T files, Alt-C dirs\n' "$(_has fzf)"
+    printf '    %s zoxide  '"'"'z <name>'"'"' smart jumping between dirs\n' "$(_has zoxide)"
+    printf '    %s eza     prettier '"'"'ls'"'"' with icons\n' "$(_has eza)"
+    local _bat=$no
+    { command -v bat &>/dev/null || command -v batcat &>/dev/null; } && _bat=$ok
+    printf '    %s bat     prettier '"'"'cat'"'"' with syntax highlighting\n' "$_bat"
+    local sug=$no
+    for _p in "$HOME/.local/share/blesh/ble.sh" \
+              "${XDG_DATA_HOME:-$HOME/.local/share}/blesh/ble.sh" \
+              "$HOMEBREW_PREFIX/share/blesh/ble.sh"; do
+        [[ -r "$_p" ]] && sug=$ok && break
+    done
+    printf '    %s ble.sh  grey ghost-text suggestions + syntax highlighting\n\n' "$sug"
+    printf '  macOS:  brew install fzf zoxide eza bat\n'
+    printf '  Debian: sudo apt install fzf zoxide eza bat\n'
+    printf '  ble.sh: https://github.com/akinomyoga/ble.sh#installation\n'
+    unset -f _has
+}

--- a/slim/base.zsh
+++ b/slim/base.zsh
@@ -1,0 +1,244 @@
+# ============================================================= #
+#  Slim zsh base — a friendly starting point for a raw zsh shell #
+# ============================================================= #
+#
+# A small, self-contained slice of a much larger dotfiles setup. It gives you
+# the good parts (fuzzy history search, autosuggestions, a git-aware prompt,
+# sensible defaults, a handful of aliases) without cloning anything in the
+# background or taking over your machine.
+#
+# Everything here degrades gracefully: if an optional tool isn't installed,
+# the related feature is quietly skipped. Run `slimhelp` any time to see what's
+# active and what you can install to unlock more.
+#
+# Install: see this folder's README.md (one line added to your ~/.zshrc).
+
+
+# --------------------------------------------------------------------------- #
+# History — remember more, remember it well
+# --------------------------------------------------------------------------- #
+HISTFILE="${HISTFILE:-$HOME/.zsh_history}"
+HISTSIZE=10000
+SAVEHIST=10000
+
+setopt HIST_IGNORE_DUPS        # don't store consecutive duplicate commands
+setopt HIST_IGNORE_SPACE       # a leading space hides a command from history
+setopt HIST_REDUCE_BLANKS      # tidy up whitespace before saving
+setopt APPEND_HISTORY          # append on exit instead of overwriting
+setopt INC_APPEND_HISTORY      # write commands as you run them (multi-shell)
+setopt SHARE_HISTORY           # new shells see history from other open shells
+
+
+# --------------------------------------------------------------------------- #
+# Sensible interactive behaviour
+# --------------------------------------------------------------------------- #
+setopt AUTO_CD                 # type a directory name to cd into it
+setopt INTERACTIVE_COMMENTS    # allow # comments at the prompt
+
+
+# --------------------------------------------------------------------------- #
+# Completion — a navigable, case-insensitive menu
+# --------------------------------------------------------------------------- #
+autoload -Uz compinit && compinit -d "${XDG_CACHE_HOME:-$HOME/.cache}/zcompdump"
+zstyle ':completion:*' menu select                       # arrow-key menu
+zstyle ':completion:*' matcher-list 'm:{a-z}={A-Za-z}'   # case-insensitive
+zstyle ':completion:*' list-colors ''                    # colourful matches
+
+
+# --------------------------------------------------------------------------- #
+# Keys — history you can actually reach
+# --------------------------------------------------------------------------- #
+# Type the start of a command, then press Up: you cycle through only the
+# history entries that begin with what you typed. This is the zero-install
+# cousin of autosuggestions and works everywhere.
+autoload -Uz up-line-or-beginning-search down-line-or-beginning-search
+zle -N up-line-or-beginning-search
+zle -N down-line-or-beginning-search
+bindkey '^[[A' up-line-or-beginning-search
+bindkey '^[[B' down-line-or-beginning-search
+bindkey '^[OA' up-line-or-beginning-search
+bindkey '^[OB' down-line-or-beginning-search
+
+# Make Home / End / Delete behave the same everywhere
+bindkey '^[[H' beginning-of-line
+bindkey '^[[F' end-of-line
+bindkey '^[[3~' delete-char
+
+
+# --------------------------------------------------------------------------- #
+# fzf — the Ctrl-R searchable history menu (and more)
+# --------------------------------------------------------------------------- #
+# With fzf installed you get:
+#   Ctrl-R  fuzzy-search your command history in a live menu
+#   Ctrl-T  fuzzy-pick a file path into the current command
+#   Alt-C   fuzzy-cd into a subdirectory
+if command -v fzf &>/dev/null; then
+    _fzf_loaded=0
+    if fzf --zsh &>/dev/null; then
+        # Modern fzf (>= 0.48): generate the integration inline, no files needed.
+        source <(fzf --zsh)
+        _fzf_loaded=1
+    else
+        # Older fzf: source the packaged shell integration if we can find it.
+        for _d in "$HOMEBREW_PREFIX/opt/fzf/shell" /usr/local/opt/fzf/shell \
+                  /usr/share/fzf /usr/share/fzf/shell /usr/share/doc/fzf/examples \
+                  "$HOME/.fzf/shell"; do
+            if [[ -r "$_d/key-bindings.zsh" ]]; then
+                source "$_d/key-bindings.zsh"
+                [[ -r "$_d/completion.zsh" ]] && source "$_d/completion.zsh"
+                _fzf_loaded=1
+                break
+            fi
+        done
+        unset _d
+    fi
+
+    # Ultimate fallback: fzf is installed but its official Ctrl-R integration
+    # wasn't found (some minimal distros don't ship it). Wire up a small history
+    # widget ourselves so the searchable menu always works.
+    if (( ! _fzf_loaded )); then
+        fzf-history-slim() {
+            local selected
+            selected=$(fc -rl 1 | fzf --tac --no-sort --query="$LBUFFER" +m |
+                       sed -E 's/^[[:space:]]*[0-9]+\*?[[:space:]]+//')
+            [[ -n "$selected" ]] && { BUFFER="$selected"; CURSOR=$#BUFFER; }
+            zle reset-prompt
+        }
+        zle -N fzf-history-slim
+        bindkey '^R' fzf-history-slim
+    fi
+    unset _fzf_loaded
+fi
+
+
+# --------------------------------------------------------------------------- #
+# Autosuggestions — the grey "ghost text" from your history
+# --------------------------------------------------------------------------- #
+# Sourced from a normal package install (brew/apt) if present. Nothing is
+# cloned or downloaded here. Install with:
+#   brew install zsh-autosuggestions      (macOS)
+#   sudo apt install zsh-autosuggestions  (Debian/Ubuntu)
+for _p in \
+    "$HOMEBREW_PREFIX/share/zsh-autosuggestions/zsh-autosuggestions.zsh" \
+    /opt/homebrew/share/zsh-autosuggestions/zsh-autosuggestions.zsh \
+    /usr/local/share/zsh-autosuggestions/zsh-autosuggestions.zsh \
+    /usr/share/zsh-autosuggestions/zsh-autosuggestions.zsh; do
+    if [[ -r "$_p" ]]; then
+        source "$_p"
+        break
+    fi
+done
+unset _p
+
+
+# --------------------------------------------------------------------------- #
+# zoxide — a smarter cd that learns your habits (optional, `z <partial-name>`)
+# --------------------------------------------------------------------------- #
+command -v zoxide &>/dev/null && eval "$(zoxide init zsh)"
+
+
+# --------------------------------------------------------------------------- #
+# A clean, git-aware prompt (no theme engine required)
+# --------------------------------------------------------------------------- #
+autoload -Uz vcs_info add-zsh-hook
+zstyle ':vcs_info:git:*' formats ' %F{magenta}⌥ %b%f'
+add-zsh-hook precmd vcs_info
+setopt PROMPT_SUBST
+PROMPT='%F{blue}%~%f${vcs_info_msg_0_}
+%(?.%F{green}.%F{red})❯%f '
+
+
+# --------------------------------------------------------------------------- #
+# A small, tasteful set of aliases
+# --------------------------------------------------------------------------- #
+# Navigation
+alias ..="cd .."
+alias ...="cd ../.."
+
+# Listing — use eza if it's around, otherwise plain ls with colour
+if command -v eza &>/dev/null; then
+    alias ls="eza --icons --color=always --group-directories-first"
+else
+    alias ls="ls --color=auto"
+fi
+alias ll="ls -lh"
+alias la="ls -a"
+alias lla="ls -lah"
+
+# Nicer cat via bat, if installed (Debian/Ubuntu ship it as `batcat`)
+if command -v bat &>/dev/null; then
+    alias cat="bat --paging=never --style=plain"
+elif command -v batcat &>/dev/null; then
+    alias cat="batcat --paging=never --style=plain"
+fi
+
+# Colourful grep
+alias grep="grep --color=auto"
+
+# Git shortcuts (the ones you'll actually type all day)
+alias gs="git status"
+alias ga="git add"
+alias gp="git pull"
+alias gd="git diff"
+alias gcm="git commit -m"
+alias gpu="git push"
+alias glog="git log --oneline"
+alias glg="git log --graph --decorate --oneline --all"
+
+# Make a directory and cd into it in one go
+mkcd() { mkdir -p -- "$1" && cd -- "$1"; }
+
+# Extract almost any archive by extension: `extract file.tar.gz`
+extract() {
+    [[ -f "$1" ]] || { echo "No such file: $1"; return 1; }
+    case "$1" in
+        *.tar.bz2|*.tbz2) tar xjf "$1" ;;
+        *.tar.gz|*.tgz)   tar xzf "$1" ;;
+        *.tar.xz)         tar xJf "$1" ;;
+        *.tar.zst)        tar --zstd -xf "$1" ;;
+        *.tar)            tar xf  "$1" ;;
+        *.bz2)            bunzip2 "$1" ;;
+        *.gz)             gunzip  "$1" ;;
+        *.xz)             xz -d   "$1" ;;
+        *.zip)            unzip   "$1" ;;
+        *.7z)             7z x    "$1" ;;
+        *.rar)            unrar x "$1" ;;
+        *) echo "Don't know how to extract: $1" ;;
+    esac
+}
+
+# Show your current public IP
+alias myip="curl -s https://ifconfig.me || curl -s https://api.ipify.org"
+
+
+# --------------------------------------------------------------------------- #
+# slimhelp — what's on, and how to unlock the rest
+# --------------------------------------------------------------------------- #
+slimhelp() {
+    local ok=$'\033[32m✓\033[0m' no=$'\033[31m✗\033[0m'
+    _has() { command -v "$1" &>/dev/null && printf '%s' "$ok" || printf '%s' "$no"; }
+
+    printf '\033[1mSlim zsh base\033[0m — feature status\n\n'
+    printf '  Always on:\n'
+    printf '    • Up-arrow prefix history search (type, then press Up)\n'
+    printf '    • Case-insensitive completion menu\n'
+    printf '    • Git-aware prompt, sensible history, handy aliases\n\n'
+    printf '  Optional tools (install to unlock more):\n'
+    printf '    %s fzf     Ctrl-R fuzzy history, Ctrl-T files, Alt-C dirs\n' "$(_has fzf)"
+    printf '    %s zoxide  '"'"'z <name>'"'"' smart jumping between dirs\n' "$(_has zoxide)"
+    printf '    %s eza     prettier '"'"'ls'"'"' with icons\n' "$(_has eza)"
+    local _bat=$no
+    { command -v bat &>/dev/null || command -v batcat &>/dev/null; } && _bat=$ok
+    printf '    %s bat     prettier '"'"'cat'"'"' with syntax highlighting\n' "$_bat"
+    local sug=$no _p
+    for _p in "$HOMEBREW_PREFIX/share/zsh-autosuggestions/zsh-autosuggestions.zsh" \
+              /opt/homebrew/share/zsh-autosuggestions/zsh-autosuggestions.zsh \
+              /usr/local/share/zsh-autosuggestions/zsh-autosuggestions.zsh \
+              /usr/share/zsh-autosuggestions/zsh-autosuggestions.zsh; do
+        [[ -r "$_p" ]] && sug=$ok && break
+    done
+    printf '    %s zsh-autosuggestions  grey ghost-text suggestions as you type\n\n' "$sug"
+    printf '  macOS:  brew install fzf zoxide eza bat zsh-autosuggestions\n'
+    printf '  Debian: sudo apt install fzf zoxide eza bat zsh-autosuggestions\n'
+    unfunction _has
+}

--- a/slim/install.sh
+++ b/slim/install.sh
@@ -1,0 +1,77 @@
+#!/usr/bin/env sh
+# Slim base installer.
+#
+# Adds a single guarded `source` line to your shell rc so the slim base loads
+# in new shells. It does NOT overwrite your rc, install packages, or clone
+# anything — it just wires up the file that already sits next to this script.
+#
+# Usage:
+#   ./install.sh            # auto-detect your shell from $SHELL
+#   ./install.sh bash       # force the bash base
+#   ./install.sh zsh        # force the zsh base
+#
+# Re-running is safe: it detects an existing install and won't add a duplicate.
+
+set -eu
+
+# Resolve the directory this script lives in (so the source line uses an
+# absolute path and keeps working no matter where you run it from).
+SCRIPT_DIR=$(CDPATH= cd -- "$(dirname -- "$0")" && pwd -P)
+
+MARKER="# >>> slim base >>>"
+ENDMARKER="# <<< slim base <<<"
+
+# --- Pick the shell --------------------------------------------------------
+shell="${1:-}"
+if [ -z "$shell" ]; then
+    case "${SHELL:-}" in
+        *zsh)  shell=zsh ;;
+        *bash) shell=bash ;;
+        *)
+            printf 'Could not detect your shell from $SHELL (%s).\n' "${SHELL:-unset}"
+            printf 'Re-run as: ./install.sh bash   or   ./install.sh zsh\n'
+            exit 1
+            ;;
+    esac
+fi
+
+case "$shell" in
+    bash) rc="$HOME/.bashrc"; base="$SCRIPT_DIR/base.bash" ;;
+    zsh)  rc="$HOME/.zshrc";  base="$SCRIPT_DIR/base.zsh" ;;
+    *)    printf 'Unknown shell: %s (expected bash or zsh)\n' "$shell"; exit 1 ;;
+esac
+
+if [ ! -r "$base" ]; then
+    printf 'Cannot find %s next to this script.\n' "$base"
+    exit 1
+fi
+
+# --- Wire it up ------------------------------------------------------------
+touch "$rc"
+if grep -qF "$MARKER" "$rc" 2>/dev/null; then
+    printf 'Slim base is already installed in %s — nothing to do.\n' "$rc"
+else
+    {
+        printf '\n%s\n' "$MARKER"
+        printf '[ -r "%s" ] && . "%s"\n' "$base" "$base"
+        printf '%s\n' "$ENDMARKER"
+    } >> "$rc"
+    printf 'Added the slim base to %s\n' "$rc"
+fi
+
+# On macOS, Terminal.app starts login shells, which read .bash_profile but not
+# .bashrc. Make sure .bash_profile pulls in .bashrc so the base actually loads.
+if [ "$shell" = bash ]; then
+    profile="$HOME/.bash_profile"
+    if [ ! -f "$profile" ] || ! grep -q 'bashrc' "$profile" 2>/dev/null; then
+        {
+            printf '\n%s\n' "$MARKER"
+            printf '[ -r "$HOME/.bashrc" ] && . "$HOME/.bashrc"\n'
+            printf '%s\n' "$ENDMARKER"
+        } >> "$profile"
+        printf 'Ensured %s sources ~/.bashrc (needed for macOS login shells)\n' "$profile"
+    fi
+fi
+
+printf '\nDone! Open a new terminal, or run:  exec %s\n' "$shell"
+printf 'Then run  slimhelp  to see what is active and what to install next.\n'


### PR DESCRIPTION
## Summary

This PR adds a complete bash port of the existing zsh configuration, enabling users without zsh to have the same feature-rich shell experience. It also introduces a new "slim" shell base—a minimal, shareable configuration for coworkers that works with both bash and zsh.

## Key Changes

### Bash Configuration (`.config/bash/`)
- **Full feature parity with zsh setup**: Mirrors the zsh structure with `lib/`, `plugins/`, and `aliases/` directories
- **Core libraries**:
  - `lib/00-utils.bash`: Shared helpers (`__ensure_commands`, `__path_prepend`, `__get_remote_resource`)
  - `lib/10-brew.bash`: Cached Homebrew shellenv initialization
  - `lib/20-completion.bash`: bash-completion integration with case-insensitive, navigable menus
  - `lib/30-env.bash`: XDG base directories, PATH setup, editor preferences
  - `lib/40-options.bash`: History configuration, shell options, keybindings
- **Plugins**:
  - `plugins/10-prompt.bash`: Starship integration with fallback to custom git-aware prompt
  - `plugins/20-suggestions.bash`: ble.sh integration for autosuggestions and syntax highlighting
  - `plugins/30-external.bash`: fzf, zoxide, and direnv integrations
- **Aliases** (all categories ported from zsh):
  - `aliases/files.bash`: File listing, viewing, and manipulation (eza, bat, jq, yq, hex utilities)
  - `aliases/navigation.bash`: Directory navigation helpers (cdg, cdp, cdup, cdfz, yazi wrapper)
  - `aliases/git.bash`: Git shortcuts and fuzzy stash/commit browsing
  - `aliases/devtools.bash`: HTTP tools, Node/Bun/Go workflows, environment inspection, emoji/gitmoji pickers
  - `aliases/system.bash`: Networking, process management, disk utilities
  - `aliases/containers.bash`: Docker and Podman shortcuts
- **Entry points**: `.bashrc` and `.bash_profile` (for macOS login shells)

### Slim Shell Base (`slim/`)
- **Minimal, zero-magic configuration** for sharing with coworkers
- **Works with both bash and zsh** from a single installation
- **No background cloning or package installation**—just one sourced file
- **Graceful degradation**: Features light up only if optional tools are installed
- **Includes**:
  - `slim/base.bash` and `slim/base.zsh`: Core configs with history, completion, fzf integration, git-aware prompts
  - `slim/install.sh`: Automated installer that adds a single guarded source line to rc files
  - `slim/README.md`: Installation and feature documentation

### Documentation
- Updated `README.md` with new directory structure and bash configuration details
- Updated `CHANGELOG.md` with comprehensive feature list

## Notable Implementation Details

- **Bash idiom translations**: zsh's `print -z` → editable `read` for command prefilling; `path` array → dedup helper function; `typeset -U` → manual dedup in `__path_prepend`
- **Prompt fallback**: Starship preferred; custom two-line git-aware prompt as fallback (no Powerlevel10k equivalent for bash)
- **History sharing**: Multi-shell friendly with `history -a` in PROMPT_COMMAND
- **Completion**: bash-completion package + readline settings for case-insensitive, navigable menus
- **Autosuggestions**: ble.sh for bash (equivalent to zsh-autosuggestions + fast-syntax-highlighting)
- **Installer safety**: Detects existing installations and won't add duplicate source lines

https://claude.ai/code/session_01WRtFyTV6ipd8w299eA4XyN